### PR TITLE
assert::is_abstract<t>() and assert::is_concrete<t>() functions

### DIFF
--- a/src/simply/assert/type_traits.h
+++ b/src/simply/assert/type_traits.h
@@ -18,6 +18,18 @@ namespace simply { namespace assert
         }
     }
 
+    template<typename actual_t>
+    void is_concrete()
+    {
+        if (std::is_abstract<actual_t>::value)
+        {
+            std::ostringstream message;
+            message << "Expected concrete type\n";
+            message << "Actual abstract type: <" << utility::type_name<actual_t>() << ">";
+            fail(message);
+        }
+    }
+
     template<typename expected_t, typename actual_t>
     void is_same()
     {      

--- a/src/simply/assert/type_traits.h
+++ b/src/simply/assert/type_traits.h
@@ -6,16 +6,26 @@
 
 namespace simply { namespace assert
 {
+    template<typename actual_t>
+    void is_abstract()
+    {
+        if (!std::is_abstract<actual_t>::value)
+        {
+            std::ostringstream message;
+            message << "Expected abstract type\n";
+            message << "Actual concrete type: <" << utility::type_name<actual_t>() << ">";
+            fail(message);
+        }
+    }
+
     template<typename expected_t, typename actual_t>
     void is_same()
     {      
-        using simply::utility::type_name;
-
         if (!std::is_same<expected_t, actual_t>::value)
         {
             std::ostringstream message;
-            message << "Expected type: <" << type_name<expected_t>() << ">\n";
-            message << "Actual type: <" << type_name<actual_t>() << ">.";
+            message << "Expected type: <" << utility::type_name<expected_t>() << ">\n";
+            message << "Actual type: <" << utility::type_name<actual_t>() << ">";
             fail(message);
         }
     }

--- a/test/assert/type_traits_test.cpp
+++ b/test/assert/type_traits_test.cpp
@@ -45,6 +45,26 @@ namespace simply
 
         #pragma endregion
 
+        #pragma region is_concrete<actual_t>()
+
+        TEST_METHOD(is_concrete_fails_when_type_is_abstract)
+        {
+            assert::is_concrete<abstract_type>();
+
+            Assert::AreNotEqual(wstring::npos, this->output.find(L"concrete"));
+            Assert::AreNotEqual(wstring::npos, this->output.find(L"abstract_type"));
+        }
+
+        TEST_METHOD(is_concrete_doesnt_fail_when_type_is_concrete)
+        {
+            assert::is_concrete<concrete_type>();
+
+            Assert::AreEqual<size_t>(0, this->output.length());
+        }
+
+        #pragma endregion
+
+
         #pragma region is_same<expected_t, actual_t>()
         
         TEST_METHOD(is_same_fails_when_types_are_different)

--- a/test/assert/type_traits_test.cpp
+++ b/test/assert/type_traits_test.cpp
@@ -12,7 +12,41 @@ namespace simply
             assert::implementation::fail,
             [&](const wstring& message) { output = message; }
         };
+
+        class abstract_type
+        {
+        public: 
+            virtual void method() = 0;
+        };
+
+        class concrete_type : public abstract_type 
+        {
+        public:
+            void method() override {}
+        };
+
     public:
+        #pragma region is_abstract<actual_t>()
+
+        TEST_METHOD(is_abstract_fails_when_type_is_concrete)
+        {
+            assert::is_abstract<concrete_type>();
+
+            Assert::AreNotEqual(wstring::npos, this->output.find(L"abstract"));
+            Assert::AreNotEqual(wstring::npos, this->output.find(L"concrete_type"));
+        }
+
+        TEST_METHOD(is_abstract_doesnt_fail_when_type_is_abstract)
+        {
+            assert::is_abstract<abstract_type>();
+
+            Assert::AreEqual<size_t>(0, this->output.length());
+        }
+
+        #pragma endregion
+
+        #pragma region is_same<expected_t, actual_t>()
+        
         TEST_METHOD(is_same_fails_when_types_are_different)
         {
             assert::is_same<int, double>();
@@ -28,5 +62,7 @@ namespace simply
             Assert::AreNotEqual(wstring::npos, this->output.find(L"volatile int"));
             Assert::AreNotEqual(wstring::npos, this->output.find(L"const int"));
         }
+
+        #pragma endregion
     };
 }


### PR DESCRIPTION
addressing #6.